### PR TITLE
Performance improvement. Lazy OBO

### DIFF
--- a/2. Web API now calls Microsoft Graph/TodoListService/Startup.cs
+++ b/2. Web API now calls Microsoft Graph/TodoListService/Startup.cs
@@ -45,7 +45,7 @@ namespace TodoListService
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddProtectWebApiWithMicrosoftIdentityPlatformV2(Configuration)
-                    .AddProtectedApiCallsWebApis(Configuration, null /*new string[] { "user.read" }*/)
+                    .AddProtectedApiCallsWebApis(Configuration)
                     .AddInMemoryTokenCaches();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/2. Web API now calls Microsoft Graph/TodoListService/Startup.cs
+++ b/2. Web API now calls Microsoft Graph/TodoListService/Startup.cs
@@ -45,7 +45,7 @@ namespace TodoListService
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddProtectWebApiWithMicrosoftIdentityPlatformV2(Configuration)
-                    .AddProtectedApiCallsWebApis(Configuration, new string[] { "user.read" })
+                    .AddProtectedApiCallsWebApis(Configuration, null /*new string[] { "user.read" }*/)
                     .AddInMemoryTokenCaches();
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/Microsoft.Identity.Web/Client/TokenAcquisition.cs
+++ b/Microsoft.Identity.Web/Client/TokenAcquisition.cs
@@ -164,7 +164,20 @@ namespace Microsoft.Identity.Web.Client
 
             // Use MSAL to get the right token to call the API
             var application = BuildConfidentialClientApplication(context, context.User);
-            return await GetAccessTokenOnBehalfOfUser(application, context.User, scopes, tenant);
+
+            // Case of a lazy OBO
+            Claim jwtClaim = context.User.FindFirst("jwt");
+            if (jwtClaim != null)
+            {
+                (context.User.Identity as ClaimsIdentity).RemoveClaim(jwtClaim);
+                var result = await application.AcquireTokenOnBehalfOf(scopes.Except(scopesRequestedByMsalNet), new UserAssertion(jwtClaim.Value))
+                                        .ExecuteAsync();
+                return result.AccessToken;
+            }
+            else
+            {
+                return await GetAccessTokenOnBehalfOfUser(application, context.User, scopes, tenant);
+            }
         }
 
         /// <summary>

--- a/Microsoft.Identity.Web/WebApiStartupHelpers.cs
+++ b/Microsoft.Identity.Web/WebApiStartupHelpers.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web.Client;
 using Microsoft.Identity.Web.Resource;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Web
@@ -65,16 +68,29 @@ namespace Microsoft.Identity.Web
             services.AddTokenAcquisition();
             services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
             {
+                // If you don't pre-provide scopes when adding calling AddProtectedApiCallsWebApis, the On behalf of
+                // flow will be delayed (lazy construction of MSAL's application
+
                 options.Events.OnTokenValidated = async context =>
                 {
-                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
-                    context.Success();
+                    if (scopes != null && scopes.Any())
+                    {
+                        var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                        context.Success();
+                        tokenAcquisition.AddAccountToCacheFromJwt(context, scopes);
+                    }
+                    else
+                    {
+                        context.Success();
 
+                        // Todo : rather use options.SaveToken?
+                        (context.Principal.Identity as ClaimsIdentity).AddClaim(new Claim("jwt", (context.SecurityToken as JwtSecurityToken).RawData));
+                    }
                     // Adds the token to the cache, and also handles the incremental consent and claim challenges
-                    tokenAcquisition.AddAccountToCacheFromJwt(context, scopes);
                     await Task.FromResult(0);
                 };
             });
+
             return services;
         }
     }

--- a/Microsoft.Identity.Web/WebApiStartupHelpers.cs
+++ b/Microsoft.Identity.Web/WebApiStartupHelpers.cs
@@ -62,8 +62,11 @@ namespace Microsoft.Identity.Web
         /// </summary>
         /// <param name="services">Service collection to which to add authentication</param>
         /// <param name="configuration">Configuration</param>
+        /// <param name="scopes">Optional parameters. If not specified, the token used to call the protected API
+        /// will be kept with the user's claims until the API calls a downstream API. Otherwise the account for the 
+        /// user is immediately added to the token cache</param>
         /// <returns></returns>
-        public static IServiceCollection AddProtectedApiCallsWebApis(this IServiceCollection services, IConfiguration configuration, IEnumerable<string> scopes)
+        public static IServiceCollection AddProtectedApiCallsWebApis(this IServiceCollection services, IConfiguration configuration, IEnumerable<string> scopes=null)
         {
             services.AddTokenAcquisition();
             services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>


### PR DESCRIPTION
## Purpose
Performance improvement.
Provide a way to not do an OBO when the token is recevied by the Web API, but only when it tries to acquire another token for a downstream API.

The reason is thare are web apis which do things without necessarilly caling a downstrream API. Delaying the OBO until needed improves the performance of these Web APIs

This PR is on to of MSAL 4"s


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->