### PR TITLE
Iss validator should take into account aliases

### DIFF
--- a/Microsoft.Identity.Web.Test/AadIssuerValidatorTests.cs
+++ b/Microsoft.Identity.Web.Test/AadIssuerValidatorTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Identity.Web.Test
     {
         private const string Tid = "9188040d-6c67-4c5b-b112-36a304b66dad";
         private static readonly string Iss = $"https://login.microsoftonline.com/{Tid}/v2.0";
+        private static readonly string Iss2 = $"https://sts.windows.net/{Tid}/v2.0";
         private static readonly IEnumerable<string> s_aliases = new[] { "login.microsoftonline.com", "sts.windows.net" };
 
         [Fact]
@@ -43,6 +44,20 @@ namespace Microsoft.Identity.Web.Test
                 new TokenValidationParameters() { ValidIssuers = new[] { "https://login.microsoftonline.com/{tenantid}/v2.0" } });
         }
 
+
+        [Fact]
+        public void PassingValidationWithAlias()
+        {
+            // Arrange
+            AadIssuerValidator validator = new AadIssuerValidator(s_aliases);
+            Claim issClaim = new Claim("tid", Tid);
+            Claim tidClaim = new Claim("iss", Iss2);  // sts.windows.net
+            JwtSecurityToken jwtSecurityToken = new JwtSecurityToken(issuer: Iss2, claims: new[] { issClaim, tidClaim });
+
+            // Act & Assert
+            validator.Validate(Iss2, jwtSecurityToken,
+                new TokenValidationParameters() { ValidIssuers = new[] { "https://login.microsoftonline.com/{tenantid}/v2.0" } });
+        }
 
         [Fact]
         public void TokenValidationParameters_ValidIssuer()

--- a/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
+++ b/Microsoft.Identity.Web/Resource/AadIssuerValidator.cs
@@ -49,11 +49,11 @@ namespace Microsoft.Identity.Web.Resource
         /// <summary>
         /// A list of all Issuers across the various Azure AD instances
         /// </summary>
-        private readonly SortedSet<string> _issuerAliases;
+        private readonly ISet<string> _issuerAliases;
 
         internal /* internal for test */ AadIssuerValidator(IEnumerable<string> aliases)
         {
-            _issuerAliases = new SortedSet<string>(aliases);
+            _issuerAliases = new HashSet<string>(aliases, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -86,8 +86,12 @@ namespace Microsoft.Identity.Web.Resource
                 }
 
                 // Add issuer aliases of the chosen authority
-                string authority = authorityHost ?? FallbackAuthority;
-                var aliases = issuerMetadata.Metadata.Where(m => m.Aliases.Any(a => a == authority)).SelectMany(m => m.Aliases).Distinct();
+                string authority = authorityHost ?? new Uri(FallbackAuthority).Host;
+                var aliases = issuerMetadata.Metadata
+                    .Where(m => m.Aliases.Any(a => string.Equals(a , authority, StringComparison.OrdinalIgnoreCase)))
+                    .SelectMany(m => m.Aliases)
+                    .Distinct();
+
                 s_issuerValidators[authority] = new AadIssuerValidator(aliases);
                 return s_issuerValidators[authority];
             }
@@ -143,15 +147,15 @@ namespace Microsoft.Identity.Web.Resource
 
             try
             {
-                var uri = new Uri(validIssuerTemplate.Replace("{tenantid}", tenantId));
+                var issuerFromTemplateUri = new Uri(validIssuerTemplate.Replace("{tenantid}", tenantId));
                 var actualIssuerUri = new Uri(actualIssuer);
 
                 // Template authority is in the aliases
-                return _issuerAliases.Contains(uri.Authority) &&
-                    // "iss" authority matches
-                    string.Equals(uri.Authority, actualIssuerUri.Authority) &&
+                return _issuerAliases.Contains(issuerFromTemplateUri.Authority) &&
+                    // "iss" authority is in the aliases
+                    _issuerAliases.Contains(actualIssuerUri.Authority) &&
                     // Template authority ends in the tenantId
-                    IsValidTidInLocalPath(tenantId, uri) &&
+                    IsValidTidInLocalPath(tenantId, issuerFromTemplateUri) &&
                     // "iss" ends in the tenantId
                     IsValidTidInLocalPath(tenantId, actualIssuerUri);
             }


### PR DESCRIPTION
Iss validator does validate if iss is from the aliases, but does not validate if ValidIssuer value is also from the aliases. This fixes it. 