### PR TITLE
Use 'TodoListClient-and-Service' in documentation

### DIFF
--- a/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README-incremental-instructions.md
+++ b/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README-incremental-instructions.md
@@ -91,12 +91,12 @@ If you want to use this automation:
    > Other ways of running the scripts are described in [App Creation Scripts](./AppCreationScripts/AppCreationScripts.md)
 
 1. Once you've run the script, be sure to follow the manual steps. Indeed Azure AD PowerShell does not yet provide full control on applications consuming v2.0 tokens, even if this registration is already possible from the Azure portal:
-   1. In the list of pages for the application registration of the *TodoListService-v2* application, select **Manifest**
+   1. In the list of pages for the application registration of the *TodoListClient-and-Service* application, select **Manifest**
       - in the manifest, search for **"accessTokenAcceptedVersion"**, and replace **null** by **2**. This property lets Azure AD know that the Web API accepts v2.0 tokens
       - search for **signInAudience** and make sure it's set to **AzureADandPersonalMicrosoftAccount**
       - Select **Save**
-   1. In the **Authentication** page for the *TodoListService-v2* application, check the `urn:ietf:wg:oauth:2.0:oob` reply URI so that the client can propose incremental consent to the user for the Web API when needed.
-   1. In tthe application registration page for the *TodoListClient-v2* application, select the **Manifest** section:
+   1. In the **Authentication** page for the *TodoListClient-and-Service* application, check the `urn:ietf:wg:oauth:2.0:oob` reply URI so that the client can propose incremental consent to the user for the Web API when needed.
+   1. In tthe application registration page for the *TodoListClient-and-Service* application, select the **Manifest** section:
       - search for **signInAudience** and make sure it's set to **AzureADandPersonalMicrosoftAccount**
       - Select **Save**
 
@@ -127,7 +127,7 @@ These instructions only show the differences with the first part.
    - Select the **Add permissions** button
    - [Optional] if you are a tenant admin, and agree to grant the admin consent to the web api, select **Grant admin consent for {your tenant domain}**.
 1. [Otherwise] If you have not granted admin consent to the Web API in the previous optional step, select **Authentication** in the list of pages and there:
-   - Check the `urn:ietf:wg:oauth:2.0:oob` Redirect URI checkbox. This is so that the client can propose incremental consent to the user for the downstream web apis used by our *TodoListService-v2* Web API.
+   - Check the `urn:ietf:wg:oauth:2.0:oob` Redirect URI checkbox. This is so that the client can propose incremental consent to the user for the downstream web apis used by our *TodoListService* Web API.
    - Select **Save**
 1. [Optional] Select the **Manifest** section and:
    - in the manifest, search for **"accessTokenAcceptedVersion"**, and see that its value is **2**. This property lets Azure AD know that the Web API accepts v2.0 tokens
@@ -147,8 +147,8 @@ This constrain is ensured by `ida:Tenant` in `TodoListClient\App.Config` having 
 #### Configure the TodoListService C# project
 
 1. Open the solution in Visual Studio.
-1. In the *TodoListService-v2* project, open the `appsettings.json` file.
-1. Find the `ClientSecret` property and replace the existing value with the key you saved during the creation of the `TodoListService-v2` app, in the Azure portal.
+1. In the *TodoListClient-and-Service* project, open the `appsettings.json` file.
+1. Find the `ClientSecret` property and replace the existing value with the key you saved during the creation of the `TodoListClient-and-Service` app, in the Azure portal.
 
 #### Configure the TodoListClient C# project
 

--- a/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README.md
+++ b/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README.md
@@ -111,7 +111,7 @@ If you want to use this automation:
    ```
    > Other ways of running the scripts are described in [App Creation Scripts](./AppCreationScripts/AppCreationScripts.md)
 
-1. In the list of pages for the application registration of the `TodoListService-v2` application, select **Manifest**
+1. In the list of pages for the application registration of the `TodoListClient-and-Service` application, select **Manifest**
       - in the manifest, search for **"accessTokenAcceptedVersion"**, and replace **null** by **2**. This property lets Azure AD know that the Web API accepts v2.0 tokens
       - Select **Save**
 
@@ -192,9 +192,9 @@ Accepted tenants can have the following values:
 Note: if you used the setup scripts, the changes below will have been applied for you
 
 1. Open the solution in Visual Studio.
-1. In the *TodoListService-v2* project, open the `appsettings.json` file.
-1. Find the `ClientId` property and replace the value with the Application ID (Client ID) property of the *TodoListService-v2* application, that you registered earlier.
-1. Find the `ClientSecret` property and replace the existing value with the key you saved during the creation of the `TodoListService-v2` app, in the Azure portal.
+1. In the *TodoListService* project, open the `appsettings.json` file.
+1. Find the `ClientId` property and replace the value with the Application ID (Client ID) property of the *TodoListClient-and-Service* application, that you registered earlier.
+1. Find the `ClientSecret` property and replace the existing value with the key you saved during the creation of the `TodoListClient-and-Service` app, in the Azure portal.
 1. [Optional] if you want to limit sign-in to users in your organization, also update the following properties:
 - `Domain`, replacing the existing value with your AAD tenant domain, for example, contoso.onmicrosoft.com.
 - `TenantId`, replacing the existing value with the Tenant ID.
@@ -203,9 +203,9 @@ Note: if you used the setup scripts, the changes below will have been applied fo
 
 Note: if you used the setup scripts, the changes below will have been applied for you
 
-1. In the TodoListClient project, open `App.config`.
-1. Find the app key `ida:ClientId` and replace the value with the ApplicationID (Client ID) for the *TodoListClient-v2* app copied from the app registration page.
-1. Find the app key `todo:TodoListScope` and replace the value with the scope of the TodoListService-v2 application copied from the app registration in the **Expose an API** tab, but replace the scope by `.default` (of the form ``api://<Application ID of service>/.default`` if you followed the instructions above)
+1. In the *TodoListClient* project, open `App.config`.
+1. Find the app key `ida:ClientId` and replace the value with the ApplicationID (Client ID) for the *TodoListClient-and-Service* app copied from the app registration page.
+1. Find the app key `todo:TodoListScope` and replace the value with the scope of the TodoListClient-and-Service application copied from the app registration in the **Expose an API** tab, but replace the scope by `.default` (of the form ``api://<Application ID of service>/.default`` if you followed the instructions above)
 1. [Optional] If you want your application to work only in your organization (only in your tenant) you'll also need to Find the app key `ida:Tenant` and replace the value with your AAD Tenant ID (GUID). Alternatively you can also use your AAD tenant Name (for example, contoso.onmicrosoft.com)
 1. [Optional] If you changed the default URL for your service application, find the app key `todo:TodoListBaseAddress` and replace the value with the base address of the TodoListService project.
 
@@ -222,7 +222,7 @@ This behavior is expected as you are not authenticated. The WPF application will
 
 Explore the sample by signing in into the TodoList client, adding items to the To Do list, removing the user account (clearing the cache), and starting again.  As explained, if you stop the application without removing the user account, the next time you run the application, you won't be prompted to sign in again. That is because the sample implements a persistent cache for MSAL, and remembers the tokens from the previous run.
 
-NOTE: Remember, the To-Do list is stored in memory in this `TodoListService-v2` sample. Each time you run the TodoListService API, your To-Do list will get emptied.
+NOTE: Remember, the To-Do list is stored in memory in this *TodoListService* sample. Each time you run the TodoListService API, your To-Do list will get emptied.
 
 ## How was the code created
 

--- a/3.-Web-api-call-Microsoft-graph-for-personal-accounts/TodoListClient/App.config
+++ b/3.-Web-api-call-Microsoft-graph-for-personal-accounts/TodoListClient/App.config
@@ -25,7 +25,7 @@
       ClientID (ApplicationID) of your application as registered in the App Registration (Preview) under Azure Active Directory
       in https://portal.azure.com
    -->
-    <add key="ida:ClientId" value="[Enter_client_ID_Of_TodoListClient-v2_from_Azure_Portal,_e.g._01234567-89ab-cdef-0123-456789abcdef]"/>
+    <add key="ida:ClientId" value="[Enter_client_ID_Of_TodoListClient-and-Service_from_Azure_Portal,_e.g._01234567-89ab-cdef-0123-456789abcdef]"/>
 
     <!--
       todo:TodoListScope is the scope of the Web API you want to call. This can be:
@@ -33,7 +33,7 @@
       - a scope corresponding to a V1 application (for instance <GUID>/user_impersonation, where  <GUID> is the
         clientId of a V1 application, created in the https://portal.azure.com portal.
     -->
-    <add key="todo:TodoListScope" value="api://[Enter_client_ID_Of_TodoListService-v2_from_Azure_Portal,_e.g._01234567-89ab-cdef-0123-456789abcdef]/access_as_user"/>
+    <add key="todo:TodoListScope" value="api://[Enter_client_ID_Of_TodoListClient-and-Service_from_Azure_Portal,_e.g._01234567-89ab-cdef-0123-456789abcdef]/access_as_user"/>
     <add key="todo:TodoListBaseAddress" value="https://localhost:44351/"/>
   </appSettings>
 </configuration>

--- a/3.-Web-api-call-Microsoft-graph-for-personal-accounts/TodoListService/appsettings.json
+++ b/3.-Web-api-call-Microsoft-graph-for-personal-accounts/TodoListService/appsettings.json
@@ -1,7 +1,7 @@
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "ClientId": "[Enter_client_ID_Of_TodoListService-v2_from_Azure_Portal,_e.g._2ec40e65-ba09-4853-bcde-bcb60029e596]",
+    "ClientId": "[Enter_client_ID_Of_TodoListClient-and-Service_from_Azure_Portal,_e.g._2ec40e65-ba09-4853-bcde-bcb60029e596]",
     "ClientSecret":  "[Enter_client_secret_as_added_fom_the_certificates_&_secrets_page_from_your_app_registration]",
 
     /*


### PR DESCRIPTION
As the shared client-id is the main purpose of this chapter, it should be the one used in sample and source.

## Purpose

* Clarifying documentation.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
Corrections to markup and 'replacement-code'

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  N/A

## What to Check
The markup and code samples refer to 'TodoListClient-and-Service' instead of 'TodoListService-v2' and 'TodoListClient-v2' as in the first two chapters.
* ...

## Other Information
IMHO newbie users like myself could need a little clarification:
"Even if your app is built to support work- or school-accounts as well as personal accounts, it will not function with work- or scool-accounts until the work- or school-admin has added your application to the organizations approved applications"