### PR TITLE
Updating IdentityModel to 6.5

### DIFF
--- a/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
+++ b/Microsoft.Identity.Web/Microsoft.Identity.Web.csproj
@@ -59,5 +59,8 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.10.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.5.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Purpose
Explicitly added these 3 references, to force the web api project to use Wilson 6.5 and fix the error *System.MissingMethodException: Method not found: 'Microsoft.IdentityModel.Tokens.SecurityKey Microsoft.IdentityModel.JsonWebTokens.JwtTokenUtilities.FindKeyMatch*
```xml
    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.0" />
    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.5.0" />
    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
```

This is a fix for #134.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->