### PR TITLE
fix yaml front-matter for sample ingestion service

### DIFF
--- a/1. Desktop app calls Web API/README.md
+++ b/1. Desktop app calls Web API/README.md
@@ -1,11 +1,4 @@
 ---
-services: active-directory
-platforms: dotnet
-author: jmprieur
-level: 200
-client: .NET Desktop (WPF)
-service: ASP.NET Core Web API
-endpoint: Microsoft identity platform
 page_type: sample
 languages:
   - csharp  
@@ -13,7 +6,6 @@ products:
   - azure
   - azure-active-directory  
   - dotnet
-  - office-ms-graph
 description: "Sign-in a user with the Microsoft Identity Platform in a WPF Desktop application and call an ASP.NET Core Web API"
 ---
 # Sign-in a user with the Microsoft Identity Platform in a WPF Desktop application and call an ASP.NET Core Web API

--- a/2. Web API now calls Microsoft Graph/README.md
+++ b/2. Web API now calls Microsoft Graph/README.md
@@ -1,11 +1,4 @@
 ---
-services: active-directory
-platforms: dotnet
-author: jmprieur
-level: 300
-client: .NET Desktop (WPF)
-service: ASP.NET Core Web API, Microsoft Graph
-endpoint: Microsoft identity platform
 page_type: sample
 languages:
   - csharp  
@@ -13,7 +6,6 @@ products:
   - azure
   - azure-active-directory  
   - aspnet-core
-  - office-ms-graph
 description: "Sign a user into a Desktop application using Microsoft Identity Platform and call a protected ASP.NET Core Web API, which calls Microsoft Graph on-behalf of the user."
 ---
 # Sign a user into a Desktop application using Microsoft Identity Platform and call a protected ASP.NET Core Web API, which calls Microsoft Graph on-behalf of the user

--- a/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README.md
+++ b/3.-Web-api-call-Microsoft-graph-for-personal-accounts/README.md
@@ -1,11 +1,4 @@
 ---
-services: active-directory
-platforms: dotnet
-author: jmprieur
-level: 300
-client: .NET Desktop (WPF)
-service: ASP.NET Core Web API, Microsoft Graph
-endpoint: Microsoft identity platform
 page_type: sample
 languages:
   - csharp  
@@ -13,7 +6,6 @@ products:
   - azure
   - azure-active-directory  
   - dotnet
-  - office-ms-graph
 description: "This sample demonstrates a .NET Desktop (WPF) application calling a ASP.NET Core Web API that is secured using Azure Active Directory"
 ---
 

--- a/4.-Console-app-calls-web-API-with-PoP/README.md
+++ b/4.-Console-app-calls-web-API-with-PoP/README.md
@@ -1,11 +1,4 @@
 ---
-services: active-directory
-platforms: dotnet
-author: jmprieur
-level: 300
-client: .NET Desktop (WPF)
-service: ASP.NET Core Web API
-endpoint: Microsoft identity platform
 page_type: sample
 languages:
   - csharp  
@@ -13,7 +6,6 @@ products:
   - azure
   - azure-active-directory  
   - dotnet
-  - office-ms-graph
 description: "Sign-in a user with the Microsoft Identity Platform in a console application and call an ASP.NET Core Web API using Proof of Possession token"
 ---
 # Sign-in a user with the Microsoft Identity Platform in a console application and call an ASP.NET Core Web API using Proof of Possession token

--- a/5.Deploy-Web-API/README.md
+++ b/5.Deploy-Web-API/README.md
@@ -5,7 +5,6 @@ languages:
 products:
 - dotnet
 - azure-active-directory
-- microsoft-graph-api
 - azure-app-services
 - azure-storage
 description: "Deploying a protected ASP.NET Core web API and calls the API from Desktop application"


### PR DESCRIPTION
This is a fix to make yaml front-matter valid in sample ingestion service

1. All the valid fields are described in: https://review.docs.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=master#yaml-front-matter-structure 
2. All the valid products and languages are described in: https://review.docs.microsoft.com/en-us/new-hope/information-architecture/metadata/taxonomies?branch=master 